### PR TITLE
Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ terraform.tfvars
 .terraform/
 *.swp*
 .chef/*
+.delivery/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+v0.2.0 (2016-03-21)
+-------------------
+- Re-wrote most of the code
+- Some formatting to make reading easier
+- Syntax updates for Terraform 0.6.14
+- Add Route53 controls
+- Add SSL certificate controls
+- Replace hostname computation from basename and count to just hostname and domain
+- Implement user and AMI mapping per [tf_chef_server](https://github.com/mengesb/tf_chef_server)
+- Remove specific IPTables handles, disabling IPTables or UFW globally
+- Better handle on delivery and keys databags
+- Provisioning using Chef provisioner and attributes_json
+- Using cookbooks at Chef server to govern system settings better than scripting EC2 variable hooks
+- Using templates instead of all HEREDOC
+- Doc and version updates
+
 v0.1.5 (2016-02-16)
 -------------------
 - Trimmed down some of the commands executed

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@ Terraform module to setup a CHEF Delivery. Requires tf_chef_server.
 
 ## Assumptions
 
-* Uses AWS
-* You will supply the AMI
-* You will supply the subnet
-* You will supply the VPC
+* Requires:
+  * AWS (duh!)
+  * AWS subnet id
+  * AWS VPC id
+  * SSL certificate/key for created instance
 * Uses a public IP and public DNS
 * Default security group implementation
   * 22/tcp: SSH
@@ -20,8 +21,10 @@ All supported OSes are 64-bit and HVM (though PV should be supported)
 
 * Ubuntu 12.04 LTS
 * Ubuntu 14.04 LTS
+* Ubuntu 16.04 LTS (pending)
 * CentOS 6 (Default)
-* CentOS 7
+* CentOS 7 (pending)
+* Others (here be dragons! Please see Map Variables)
 
 ## AWS
 
@@ -32,30 +35,76 @@ These resources will incur charges on your AWS bill. It is your responsibility t
 ### AWS variables
 
 * `aws_access_key`: Your AWS key, usually referred to as `AWS_ACCESS_KEY_ID`
-* `aws_secret_key`: Your secret for your AWS key, usually referred to as `AWS_SECRET_ACCESS_KEY`
-* `aws_region`: AWS region you want to deploy to. Default: `us-west-1`
+* `aws_flavor`: The AWS instance type. Default: `c3.xlarge`
 * `aws_key_name`: The private key pair name on AWS to use (String)
 * `aws_private_key_file`: The full path to the private kye matching `aws_key_name` public key on AWS
-* `aws_vpc_id`: The AWS id of the VPC to use. Example: `vpc-ffffffff`
+* `aws_region`: AWS region you want to deploy to. Default: `us-west-1`
+* `aws_secret_key`: Your secret for your AWS key, usually referred to as `AWS_SECRET_ACCESS_KEY`
 * `aws_subnet_id`: The AWS id of the subnet to use. Example: `subnet-ffffffff`
-* `aws_ami_user`: The user for the AMI you're using. Example: `centos`
-* `aws_ami_id`: The AWS id of the AMI. Default: `ami-45844401` [CentOS 6 (x86_64) - with Updates HVM (us-west-1)](https://aws.amazon.com/marketplace/pp/B00NQAYLWO)
-* `aws_flavor`: The AWS instance type. Default: `c3.xlarge`
+* `aws_vpc_id`: The AWS id of the VPC to use. Example: `vpc-ffffffff`
 
 ### tf_chef_delivery variables
 
-* `basename`: Delivery server's basename. Default: `chef-delivery`
-* `count`: Delivery server count. Deafult: `1`, DO NOT CHANGE!
-* `enterprise`: Delivery enterprise to create. Default `Terraform`
+* `allowed_cidrs`: The comma seperated list of addresses in CIDR format to allow SSH access. Default `0.0.0.0/0`
+* `domain`: Delivery server's domain. Default: 'localdomain'
+* `chef_fqdn`: DNS address of the CHEF Server
+* `chef_org_short`: CHEF Server organization.
+* `chef_sg`: CHEF Server security group id.
+* `ent`: Delivery enterprise to create. Default `Terraform`
+* `hostname`: Delivery server's hostname. Default: `delivery-01`
+* `license_file`: Path to the `delivery.license` file
+* `r53`: Boolean determines if Route53 will be used or not. Default: `0`
+* `r53_ttl`: Time to Live (TTL) setting for Route53 A record to be created. Default: `180`
+* `r53_zone_id`: AWS Route53 Zone ID to add an A record for the Chef Server
+* `secret_key_file`: Encrypted data bag secret file.
+* `server_count`: Delivery server count. Deafult: `1`, DO NOT CHANGE!
+* `ssl_cert`: Delivery server SSL certificate in PEM format
+* `ssl_key`: Delivery server SSL certificate key
+* `tag_description`: Text field tag 'Description'
 * `username`: Delivery username on CHEF Server. Default `delivery`
 * `user_firstname`: Delivery user first name. Default `Delivery`
 * `user_lastname`: Delivery user last name. Default `User`
-* `ssh_cidrs`: The comma seperated list of addresses in CIDR format to allow SSH access. Default `0.0.0.0/0`
-* `license_file`: Path to the `delivery.license` file
-* `chef_server_dns`: DNS address of the CHEF Server
-* `chef_org_short`: CHEF Server organization.
-* `chef_server_sg`: CHEF Server security group id.
-* `secret_key_file`: Encrypted data bag secret file.
+
+### Map variables
+
+The below mapping variables construct selection criteria
+
+* `ami_map`: AMI selection map comprised of `ami_os` and `aws_region`
+* `ami_usermap`: Default username selection map based off `ami_os`
+
+The `ami_map` is a combination of `ami_os` and `aws_region` which declares the AMI selected. To override this pre-declared AMI, define
+
+```
+ami_map.<ami_os>-<aws_region> = "value"
+```
+
+Variable `ami_os` should be one of the following:
+
+* centos6 (default)
+* centos7
+* ubuntu12
+* ubuntu14
+* ubuntu16
+
+Variable `aws_region` should be one of the following:
+
+* us-east-1
+* us-west-2
+* us-west-1 (default)
+* eu-central-1
+* eu-west-1
+* ap-southeast-1
+* ap-southeast-2
+* ap-northeast-1
+* ap-northeast-2
+* sa-east-1
+* Custom (must be an AWS region, requires setting `ami_map` and setting AMI value)
+
+Map `ami_usermap` uses `ami_os` to look the default username for interracting with the instance. To override this pre-declared user, define
+
+```
+ami_usermap.<ami_os> = "value"
+```
 
 ## Outputs
 

--- a/files/attributes-json.tpl
+++ b/files/attributes-json.tpl
@@ -1,0 +1,19 @@
+{
+  "delivery-cluster": {
+    "delivery": {
+      "chef_server": "https://${chef_fqdn}/organizations/${chef_org}",
+      "fqdn": "${host}.${domain}"
+    }
+  },
+  "fqdn": "${host}.${domain}",
+  "firewall": {
+    "allow_established": true,
+    "allow_ssh": true
+  },
+  "system": {
+    "short_hostname": "${host}",
+    "domain_name": "${domain}",
+    "manage_hostsfile": true
+  },
+  "tags": []
+}

--- a/files/chef-cookbooks.sh
+++ b/files/chef-cookbooks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+[ -x /usr/bin/yum ] && sudo yum -q -y install git || sudo apt-get -qq install git
+sudo rm -rf /var/chef/cookbooks
+sudo mkdir -p /var/chef/cookbooks
+for DEP in apt apt-chef build-essential   ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
+for DEP in chef-ingredient git 7-zip      ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
+for DEP in chef-splunk chef-sugar cron    ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
+for DEP in delivery-base delivery_build   ; do sudo git clone -q --depth=1 https://github.com/chef-cookbooks/${DEP} /var/chef/cookbooks/${DEP}   ; done
+for DEP in delivery-cluster               ; do sudo git clone -q --depth=1 https://github.com/chef-cookbooks/${DEP} /var/chef/cookbooks/${DEP}   ; done
+for DEP in firewall hostsfile packagecloud; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
+for DEP in push-jobs system yum yum-chef  ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
+for DEP in chef-vault windows             ; do curl -sL https://supermarket.chef.io/cookbooks/${DEP}/download | sudo tar xzC /var/chef/cookbooks; done
+sudo cp -rp /var/chef/cookbooks/delivery-cluster/vendor/chef-server-12 /var/chef/cookbooks
+sudo chown -R root:root /var/chef/cookbooks
+echo Finished

--- a/files/delivery-builder-keys-json.tpl
+++ b/files/delivery-builder-keys-json.tpl
@@ -1,0 +1,4 @@
+{
+  "id": "delivery_builder_keys",
+  "builder_key": "text1"
+}

--- a/files/delivery-json.tpl
+++ b/files/delivery-json.tpl
@@ -1,0 +1,4 @@
+{
+  "id": "delivery",
+  "delivery_pem": "text2"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,255 +1,294 @@
-# CHEF Delivery AWS security group - https://github.com/chef-cookbooks/delivery-cluster
+# Chef Delivery AWS security group - https://github.com/Chef-cookbooks/delivery-cluster
 resource "aws_security_group" "chef-delivery" {
-  name = "chef-delivery"
-  description = "CHEF Delivery"
-  vpc_id = "${var.aws_vpc_id}"
-  tags = {
-    Name = "chef-delivery security group"
+  name        = "${var.hostname}.${var.domain} security group"
+  description = "Delivery server ${var.hostname}.${var.domain}"
+  vpc_id      = "${var.aws_vpc_id}"
+  tags        = {
+    Name      = "${var.hostname}.${var.domain} security group"
   }
 }
-# Allow all from CHEF Server
-resource "aws_security_group_rule" "chef-delivery_allow_all_chef-server" {
-  type = "ingress"
-  from_port = 0
-  to_port = 65535
-  protocol = "-1"
-  source_security_group_id = "${var.chef_server_sg}"
+# Chef Server -> Delivery
+resource "aws_security_group_rule" "chef-delivery_allow_all_Chef-server" {
+  type        = "ingress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  source_security_group_id = "${var.chef_sg}"
   security_group_id = "${aws_security_group.chef-delivery.id}"
 }
-# Allow all from CHEF Delivery to CHEF Server
+# Delivery -> Chef Server
 resource "aws_security_group_rule" "chef-server_allow_all_chef-delivery" {
-  type = "ingress"
-  from_port = 0
-  to_port = 65535
-  protocol = "-1"
+  type        = "ingress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
   source_security_group_id = "${aws_security_group.chef-delivery.id}"
-  security_group_id = "${var.chef_server_sg}"
+  security_group_id = "${var.chef_sg}"
 }
-# SSH - all
+# SSH - allowed_cidrs
 resource "aws_security_group_rule" "chef-delivery_allow_22_tcp_all" {
-  type = "ingress"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["${split(",", var.ssh_cidrs)}"]
+  type        = "ingress"
+  from_port   = 22
+  to_port     = 22
+  protocol    = "tcp"
+  cidr_blocks = ["${split(",", var.allowed_cidrs)}"]
   security_group_id = "${aws_security_group.chef-delivery.id}"
 }
 # HTTP (nginx)
 resource "aws_security_group_rule" "chef-delivery_allow_80_tcp_all" {
-  type = "ingress"
-  from_port = 80
-  to_port = 80
-  protocol = "tcp"
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.chef-delivery.id}"
 }
 # HTTPS (nginx)
 resource "aws_security_group_rule" "chef-delivery_allow_443_tcp_all" {
-  type = "ingress"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.chef-delivery.id}"
 }
 # Delivery GIT
 resource "aws_security_group_rule" "chef-delivery_allow_8989_tcp_all" {
-  type = "ingress"
-  from_port = 8989
-  to_port = 8989
-  protocol = "tcp"
+  type        = "ingress"
+  from_port   = 8989
+  to_port     = 8989
+  protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.chef-delivery.id}"
 }
 # Egress: ALL
 resource "aws_security_group_rule" "chef-delivery_allow_all" {
-  type = "egress"
-  from_port = 0
-  to_port = 65535
-  protocol = "-1"
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.chef-delivery.id}"
 }
-# CHEF Delivery requirements
-resource "null_resource" "chef-delivery-requirements" {
-  # Create CHEF Delivery user on CHEF Server
+#
+# Chef Delivery requirements
+#
+resource "template_file" "attributes-json" {
+  template    = "${file("${path.module}/files/attributes-json.tpl")}"
+  vars {
+    chef_fqdn = "${var.chef_fqdn}"
+    chef_org  = "${var.chef_org}"
+    host      = "${var.hostname}"
+    domain    = "${var.domain}"
+  }
+}
+resource "template_file" "builder-json" {
+  template = "${file("${path.module}/files/delivery-builder-keys-json.tpl")}"
+}
+resource "template_file" "delivery-json" {
+  template = "${file("${path.module}/files/delivery-json.tpl")}"
+}
+resource "null_resource" "clean-slate" {
+  provisioner "local-exec" {
+    command = "rm -rf .delivery ; mkdir -p .delivery"
+  }
+}
+resource "null_resource" "delivery-user" {
+  depends_on = ["null_resource.clean-slate"]
+  connection {
+    user        = "${lookup(var.ami_usermap, var.ami_os)}"
+    private_key = "${var.aws_private_key_file}"
+    host        = "${var.chef_fqdn}"
+  }
   provisioner "remote-exec" {
-    connection {
-      user = "${var.aws_ami_user}"
-      private_key = "${var.aws_private_key_file}"
-      host = "${var.chef_server_dns}"
-    }
     inline = [
-      "echo 'Adding ${var.username}' to CHEF Server",
-      "sudo chef-server-ctl user-create ${var.username} ${var.user_firstname} ${var.user_lastname} ${var.user_email} ${base64encode(self.id)} -f /tmp/.chef/${var.username}.pem",
-      "sudo chef-server-ctl org-user-add ${var.chef_org_short} ${var.username}",
-      "echo Prepared for Delivery provisioning"
+      "rm -rf .delivery ; mkdir .delivery",
+      "sudo chef-server-ctl org-user-remove ${var.chef_org} ${var.username} --force -y || echo OK",
+      "sudo chef-server-ctl user-delete ${var.username} -y || echo OK",
+      "sudo chef-server-ctl user-create ${var.username} ${var.user_firstname} ${var.user_lastname} ${var.user_email} ${base64sha256(self.id)} -f .delivery/${var.username}.pem",
+      "sudo chef-server-ctl org-user-add ${var.chef_org} ${var.username} -a",
+      "sudo chown -R ${lookup(var.ami_usermap, var.ami_os)} .delivery",
     ]
   }
-  # Copy back Delivery user pem
   provisioner "local-exec" {
-    command  = "scp -o StrictHostKeyChecking=no -i ${var.aws_private_key_file} ${var.aws_ami_user}@${var.chef_server_dns}:/tmp/.chef/${var.username}.pem ${path.cwd}/.chef/${var.username}.pem"
+    command = "scp -o stricthostkeychecking=no -i ${var.aws_private_key_file} ${lookup(var.ami_usermap, var.ami_os)}@${var.chef_fqdn}:.delivery/${var.username}.pem .delivery/${var.username}.pem"
   }
-  # Create JSON file for databag
   provisioner "local-exec" {
-    command = <<EOF
-rm -f ${path.cwd}/.chef/delivery_builder_keys.json
-rm -f ${path.cwd}/.chef/builder_key ${path.cwd}/.chef/builder_key.pub ${path.cwd}/.chef/builder_key.pem
-rm -f ${path.cwd}/.chef/builder_key_databag ${path.cwd}/.chef/${var.username}_key_databag
-cat > ${path.cwd}/.chef/delivery_builder_keys.json <<EOK
-{
-"id": "delivery_builder_keys",
-"builder_key": "BUILDER_KEY",
-"delivery_pem": "DELIVERY_PEM"
-}
-EOK
-ssh-keygen -q -t rsa -N '' -b 2048 -f ${path.cwd}/.chef/builder_key
-ssh-keygen -q -f ${path.cwd}/.chef/builder_key -e -m 'PEM' > ${path.cwd}/.chef/builder_key.pem
-cp ${path.cwd}/.chef/builder_key.pem ${path.cwd}/.chef/builder_key_databag
-cp ${path.cwd}/.chef/${var.username}.pem ${path.cwd}/.chef/${var.username}_key_databag
-perl -pe 's/\n/\\n/g' -i ${path.cwd}/.chef/builder_key_databag
-perl -pe 's/\n/\\n/g' -i ${path.cwd}/.chef/${var.username}_key_databag
-cd ${path.cwd}/.chef && perl -pe 's/BUILDER_KEY/`cat builder_key_databag`/ge' -i ${path.cwd}/.chef/delivery_builder_keys.json
-cd ${path.cwd}/.chef && perl -pe 's/DELIVERY_PEM/`cat ${var.username}_key_databag`/ge' -i ${path.cwd}/.chef/delivery_builder_keys.json
-knife data bag create keys
-knife data bag from file keys ${path.cwd}/.chef/delivery_builder_keys.json --encrypt --secret-file ${var.secret_key_file}
-cat ${path.cwd}/.chef/delivery_builder_keys.json
+    command = <<EOC
+cat .delivery/${var.username}.pem | perl -pe 's/\n/\\n/g' > .delivery/${var.username}_databag
+cat > .delivery/delivery.json <<EOF
+${template_file.delivery-json.rendered}
 EOF
+cd .delivery && perl -pe 's/text2/`cat ${var.username}_databag`/ge' -i delivery.json
+EOC
   }
 }
-# CHEF Delivery
+resource "null_resource" "delivery-server" {
+  depends_on = ["null_resource.clean-slate"]
+  provisioner "local-exec" {
+    command = "knife node-delete ${var.hostname}.${var.domain} -y ; echo OK"
+  }
+  provisioner "local-exec" {
+    command = "knife client-delete ${var.hostname}.${var.domain} -y ; echo OK"
+  }
+}
+resource "null_resource" "builder-key" {
+  depends_on = ["null_resource.clean-slate"]
+  provisioner "local-exec" {
+    command = "ssh-keygen -q -t rsa -N '' -b 2048 -f .delivery/builder_key"
+  }
+  provisioner "local-exec" {
+    command = <<EOC
+cat .delivery/builder_key | perl -pe 's/\n/\\n/g' > .delivery/builder_databag
+cat > .delivery/delivery_builder_keys.json <<EOF
+${template_file.builder-json.rendered}
+EOF
+cd .delivery && perl -pe 's/text1/`cat builder_databag`/ge' -i delivery_builder_keys.json
+EOC
+  }
+}
+resource "null_resource" "delivery-cookbooks" {
+  depends_on = ["null_resource.clean-slate"]
+  connection {
+    user        = "${lookup(var.ami_usermap, var.ami_os)}"
+    private_key = "${var.aws_private_key_file}"
+    host        = "${var.chef_fqdn}"
+  }
+  provisioner "file" {
+    source      = "${path.module}/files/chef-cookbooks.sh"
+    destination = "chef-cookbooks.sh"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "bash chef-cookbooks.sh ; rm -rf chef-cookbooks.sh",
+    ]
+  }
+}
+#
+# Chef Delivery
+#
 resource "aws_instance" "chef-delivery" {
-  ami = "${var.aws_ami_id}"
-  count = "${var.count}"
+  depends_on    = ["null_resource.builder-key","null_resource.delivery-user","null_resource.delivery-server","null_resource.delivery-cookbooks"]
+  ami           = "${lookup(var.ami_map, format("%s-%s", var.ami_os, var.aws_region))}"
+  count         = "${var.server_count}"
   instance_type = "${var.aws_flavor}"
-  subnet_id = "${var.aws_subnet_id}"
+  subnet_id     = "${var.aws_subnet_id}"
   vpc_security_group_ids = ["${aws_security_group.chef-delivery.id}"]
-  key_name = "${var.aws_key_name}"
+  key_name      = "${var.aws_key_name}"
   tags = {
-    Name = "${format("%s-%02d", var.basename, count.index + 1)}"
+    Name        = "${var.hostname}.${var.domain}"
   }
   root_block_device = {
     delete_on_termination = true
   }
   connection {
-    user = "${var.aws_ami_user}"
+    user        = "${lookup(var.ami_usermap, var.ami_os)}"
     private_key = "${var.aws_private_key_file}"
+    host        = "${self.public_ip}"
   }
   # Create path to delivery license
   provisioner "remote-exec" {
     inline = [
-      "mkdir -p /tmp/.chef",
+      "mkdir -p .delivery",
       "sudo mkdir -p /var/opt/delivery/license /etc/delivery /etc/chef"
     ]
   }
-  # Hostname setup
-  provisioner "remote-exec" {
-    inline = [
-      "EC2IPV4=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)",
-      "echo $EC2IPV4",
-      "EC2FQDN=$(curl http://169.254.169.254/latest/meta-data/public-hostname)",
-      "EC2HOST=$(echo $EC2FQDN | sed 's/..*//')",
-      "EC2DOMA=$(echo $EC2FQDN | sed \"s/$EC2HOST.//\")",
-      "sudo sed -i '/localhost/{n;s/^/${self.public_ip} ${self.public_dns}\\n/}' /etc/hosts",
-      "[ -f /etc/sysconfig/network ] && sudo hostname ${self.public_dns} || sudo hostname $EC2HOST",
-      "echo ${self.public_dns}|sed 's/\\..*//' > /tmp/hostname",
-      "sudo chown root:root /tmp/hostname",
-      "[ -f /etc/sysconfig/network ] && sudo sed -i 's/^HOSTNAME.*/HOSTNAME=${self.public_dns}/' /etc/sysconfig/network || sudo cp /tmp/hostname /etc/hostname",
-      "sudo rm /tmp/hostname"
-    ]
-  }
-  # Copy over trusted certificates
-  provisioner "file" {
-    source = "${path.cwd}/.chef/trusted_certs"
-    destination = "/tmp/.chef"
-  }
   # Copy over Delivery user PEM
   provisioner "file" {
-    source = "${path.cwd}/.chef/${var.username}.pem"
-    destination = "/tmp/.chef/${var.username}.pem"
+    source      = ".delivery/${var.username}.pem"
+    destination = ".delivery/${var.username}.pem"
   }
   # Copy in license file
   provisioner "file" {
-    source = "${var.license_file}"
-    destination = "/tmp/.chef/delivery.license"
+    source      = "${var.delivery_license}"
+    destination = ".delivery/delivery.license"
   }
   # Copy in builder key pair
   provisioner "file" {
-    source = "${path.cwd}/.chef/builder_key"
-    destination = "/tmp/.chef/builder_key"
+    source      = ".delivery/builder_key"
+    destination = ".delivery/builder_key"
   }
   provisioner "file" {
-    source = "${path.cwd}/.chef/builder_key.pub"
-    destination = "/tmp/.chef/builder_key.pub"
+    source      = ".delivery/builder_key.pub"
+    destination = ".delivery/builder_key.pub"
   }
   # Put files in proper locations
   provisioner "remote-exec" {
     inline = [
-      "sudo mv /tmp/.chef/delivery.license /var/opt/delivery/license",
-      "sudo mv /tmp/.chef/${var.username}.pem /etc/delivery/${var.username}.pem",
-      "sudo mv /tmp/.chef/builder_key.pub /etc/delivery/builder_key.pub",
-      "sudo mv /tmp/.chef/trusted_certs /etc/chef",
+      "sudo mv .delivery/delivery.license /var/opt/delivery/license",
+      "sudo mv .delivery/* /etc/delivery",
+      "sudo chown -R delivery /etc/delivery/builder_key /etc/delivery/builder_key.pub",
       "sudo chown -R root:root /var/opt/delivery/license /etc/delivery /etc/chef"
     ]
   }
   # Handle iptables
   provisioner "remote-exec" {
     inline = [
-      "sudo iptables -F",
-      "sudo iptables -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT",
-      "sudo iptables -A INPUT -p icmp -j ACCEPT",
-      "sudo iptables -A INPUT -i lo -j ACCEPT",
-      "sudo iptables -A INPUT -p tcp -m state --state NEW -m tcp --dport 22 -j ACCEPT",
-      "sudo iptables -A INPUT -p tcp -m multiport --dports 80,443,8989 -j ACCEPT",
-      "sudo iptables -A INPUT -j REJECT --reject-with icmp-host-prohibited",
-      "sudo iptables -A FORWARD -j REJECT --reject-with icmp-host-prohibited",
-      "sudo service iptables save",
-      "sudo service iptables restart"
+      "sudo service iptables stop",
+      "sudo chkconfig iptables off",
+      "sudo ufw disable",
+      "echo Say WHAT one more time"
     ]
   }
-  # Provision with CHEF
+  # Provision with Chef
   provisioner "chef" {
-    attributes {
-      "delivery-cluster" {
-        "delivery" {
-          "chef_server" = "https://${var.chef_server_dns}/organizations/${var.chef_org_short}"
-          "fqdn" = "${self.public_dns}"
-        }
-      }
-    }
-    # environment = "_default"
-    run_list = ["delivery-cluster::delivery"]
-    node_name = "${format("%s-%02d", var.basename, count.index + 1)}"
-    secret_key = "${file("${var.secret_key_file}")}"
-    server_url = "https://${var.chef_server_dns}/organizations/${var.chef_org_short}"
-    validation_client_name = "${var.chef_org_short}-validator"
-    validation_key = "${file("${path.cwd}/.chef/${var.chef_org_short}-validator.pem")}"
+    attributes_json = "${template_file.attributes-json.rendered}"
+    # environment     = "_default"
+    run_list        = ["system::default","delivery-cluster::delivery"]
+    node_name       = "${var.hostname}.${var.domain}"
+    secret_key      = "${file("${var.secret_key_file}")}"
+    server_url      = "https://${var.chef_fqdn}/organizations/${var.chef_org}"
+    validation_client_name = "${var.chef_org}-validator"
+    validation_key  = "${file("${var.chef_org_validator}")}"
+  }
+  # Place SSL certificate/key files
+  provisioner "file" {
+    source      = "${var.ssl_cert}"
+    destination = ".delivery/certificate.pem"
+  }
+  provisioner "file" {
+    source      = "${var.ssl_key}"
+    destination = ".delivery/certificate.key"
+  }
+  # Replace the SSL certificate on Delivery
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv .delivery/certificate.pem /var/opt/delivery/nginx/ca/${self.tags.Name}.crt",
+      "sudo mv .delivery/certificate.key /var/opt/delivery/nginx/ca/${self.tags.Name}.key",
+      "sudo delivery-ctl reconfigure",
+      "sudo delivery-ctl restart nginx",
+    ]
   }
   # Set permissions and file placement
   provisioner "remote-exec" {
     inline = [
-      "sudo mv /tmp/.chef/builder_key /etc/delivery/builder_key",
-      "sudo chown -R delivery:${var.aws_ami_user} /etc/delivery/builder_key /etc/delivery/builder_key.pub",
-      "sudo chmod 0600 /etc/delivery/builder_key",
-      "sudo chmod 0644 /etc/delivery/builder_key.pub"
+      "sudo chown -R delivery:${lookup(var.ami_usermap, var.ami_os)} /etc/delivery/builder_key /etc/delivery/builder_key.pub",
+      "sudo chmod 0600 /etc/delivery/builder_key /etc/delivery/${var.username}.pem",
+      "sudo chmod 0644 /etc/delivery/builder_key.pub",
     ]
   }
-  # Generate CHEF Delivery enterprise credentials file
+  # Generate Chef Delivery enterprise credentials file
   provisioner "remote-exec" {
     inline = [
-      "sudo chown -R ${var.aws_ami_user}:${var.aws_ami_user} /tmp/.chef",
-      "sudo delivery-ctl create-enterprise ${var.enterprise} --ssh-pub-key-file=/etc/delivery/builder_key.pub > /tmp/.chef/${var.enterprise}.creds",
-      "sudo chown ${var.aws_ami_user}:${var.aws_ami_user} /tmp/.chef/${var.enterprise}.creds",
-      "cat /tmp/.chef/${var.enterprise}.creds"
+      "sudo chown -R ${lookup(var.ami_usermap, var.ami_os)} .delivery",
+      "sudo delivery-ctl create-enterprise ${var.ent} --ssh-pub-key-file=/etc/delivery/builder_key.pub > .delivery/${var.ent}.creds",
+      "sudo chown -R ${lookup(var.ami_usermap, var.ami_os)} .delivery",
     ]
   }
-  # Copy back CHEF Delivery enterprise credentials file
+  # Copy back Chef Delivery enterprise credentials file
   provisioner "local-exec" {
-    command  = "scp -o StrictHostKeyChecking=no -i ${var.aws_private_key_file} ${var.aws_ami_user}@${self.public_dns}:/tmp/.chef/${var.enterprise}.creds ${path.cwd}/.chef/${var.enterprise}.creds"
+    command = "scp -o StrictHostKeyChecking=no -i ${var.aws_private_key_file} ${lookup(var.ami_usermap, var.ami_os)}@${self.public_ip}:.delivery/${var.ent}.creds .delivery/${var.ent}.creds"
   }
   # Local echo
   provisioner "local-exec" {
-    command = "cat ${path.cwd}/.chef/${var.enterprise}.creds"
+    command = "cat .delivery/${var.ent}.creds"
   }
 }
-
+# Public Route53 DNS record
+resource "aws_route53_record" "chef-delivery" {
+  zone_id = "${var.r53_zone_id}"
+  name    = "${aws_instance.chef-delivery.tags.Name}"
+  type    = "A"
+  ttl     = "${var.r53_ttl}"
+  records = ["${aws_instance.chef-delivery.public_ip}"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 # Outputs
-output "delivery_creds" {
-  value = "\n${file(".chef/${var.enterprise}.creds")}"
+output "credentials" {
+  value = "\n${file(".delivery/${var.ent}.creds")}"
 }
-output "public_dns" {
-  value = "${aws_instance.chef-delivery.public_dns}"
+output "fqdn" {
+  value = "${aws_instance.chef-delivery.tags.Name}"
 }
 output "security_group_id" {
   value = "${aws_security_group.chef-delivery.id}"

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,10 @@ variable "aws_access_key" {
 variable "aws_secret_key" {
   description = "Your AWS secret (ex. $AWS_SECRET_ACCESS_KEY)"
 }
+variable "aws_region" {
+  description = "AWS Region to deploy to"
+  default     = "us-west-1"
+}
 variable "aws_key_name" {
   description = "Name of the key pair uploaded to AWS"
 }
@@ -19,68 +23,155 @@ variable "aws_vpc_id" {
 variable "aws_subnet_id" {
   description = "AWS Subnet id (ex. subnet-ffffffff)"
 }
-variable "aws_ami_user" {
-  description = "AWS AMI default username"
-}
-variable "aws_ami_id" {
-  description = "AWS Instance ID (region dependent)"
-  default = "ami-45844401"
-}
 variable "aws_flavor" {
   description = "AWS Instance type to deploy"
-  default = "c3.xlarge"
+  default     = "c3.xlarge"
 }
-variable "aws_region" {
-  description = "AWS Region to deploy to"
-  default = "us-west-1"
+variable "ami_os" {
+  description = "Delivery server OS (options: centos7, [centos6], ubuntu16, ubuntu14)"
+  default     = "centos6"
+}
+variable "ami_map" {
+  description = "AMI map of OS/region (2016-03-14)"
+  default     = {
+    centos7-us-east-1       = "ami-6d1c2007"
+    centos7-us-west-2       = "ami-d2c924b2"
+    centos7-us-west-1       = "ami-af4333cf"
+    centos7-eu-central-1    = "ami-9bf712f4"
+    centos7-eu-west-1       = "ami-7abd0209"
+    centos7-ap-southeast-1  = "ami-f068a193"
+    centos7-ap-southeast-2  = "ami-fedafc9d"
+    centos7-ap-northeast-1  = "ami-eec1c380"
+    centos7-ap-northeast-2  = "ami-c74789a9"
+    centos7-sa-east-1       = "ami-26b93b4a"
+    centos6-us-east-1       = "ami-1c221e76"
+    centos6-us-west-2       = "ami-05cf2265"
+    centos6-us-west-1       = "ami-ac5f2fcc"
+    centos6-eu-central-1    = "ami-2bf11444"
+    centos6-eu-west-1       = "ami-edb9069e"
+    centos6-ap-southeast-1  = "ami-106aa373"
+    centos6-ap-southeast-2  = "ami-87d2f4e4"
+    centos6-ap-northeast-1  = "ami-fa3d3f94"
+    centos6-ap-northeast-2  = "ami-56478938"
+    centos6-sa-east-1       = "ami-03b93b6f"
+    ubuntu16-us-east-1      = "-1"
+    ubuntu16-us-west-2      = "-1"
+    ubuntu16-us-west-1      = "-1"
+    ubuntu16-eu-central-1   = "-1"
+    ubuntu16-eu-west-1      = "-1"
+    ubuntu16-ap-southeast-1 = "-1"
+    ubuntu16-ap-southeast-2 = "-1"
+    ubuntu16-ap-northeast-1 = "-1"
+    ubuntu16-ap-northeast-2 = "-1"
+    ubuntu16-sa-east-1      = "-1"
+    ubuntu14-us-east-1      = "ami-415f6d2b"
+    ubuntu14-us-west-2      = "ami-3d2cce5d"
+    ubuntu14-us-west-1      = "ami-1d25557d"
+    ubuntu14-eu-central-1   = "ami-9b9c86f7"
+    ubuntu14-eu-west-1      = "ami-abc579d8"
+    ubuntu14-ap-southeast-1 = "ami-f500c996"
+    ubuntu14-ap-southeast-2 = "ami-1f30167c"
+    ubuntu14-ap-northeast-1 = "ami-88686be6"
+    ubuntu14-ap-northeast-2 = "-1"
+    ubuntu14-sa-east-1      = "ami-f3e4669f"
+    ubuntu12-us-east-1      = "ami-88dfdee2"
+    ubuntu12-us-west-2      = "ami-1a977e7a"
+    ubuntu12-us-west-1      = "ami-4f285a2f"
+    ubuntu12-eu-central-1   = "ami-3cf61153"
+    ubuntu12-eu-west-1      = "ami-65932916"
+    ubuntu12-ap-southeast-1 = "ami-26e32845"
+    ubuntu12-ap-southeast-2 = "ami-d54e6eb6"
+    ubuntu12-ap-northeast-1 = "ami-f2afa79c"
+    ubuntu12-ap-northeast-2 = "-1"
+    ubuntu12-sa-east-1      = "ami-2661ec4a"
+  }
+}
+variable "ami_usermap" {
+  description = "Default username map for AMI selected"
+  default     = {
+    centos7   = "centos"
+    centos6   = "centos"
+    ubuntu16  = "ubuntu"
+    ubuntu14  = "ubuntu"
+    ubuntu12  = "ubuntu"
+  }
 }
 #
-# tf_chef_delivery_server specific configs
+# specific configs
 #
-variable "basename" {
-  description = "Basename for AWS Name tag of CHEF Delivery server"
-  default = "chef-delivery"
+variable "tag_description" {
+  description = "Delivery server AWS description tag text"
+  default     = "Created using Terraform (tf_Chef_delivery)"
 }
-variable "count" {
-  description = "Number of CHEF Delivery servers to provision. DO NOT CHANGE!"
-  default = 1
+variable "hostname" {
+  description = "Delivery server hostname"
+  default     = "localhost"
 }
-variable "enterprise" {
-  description = "Name of the CHEF Delivery enterprise to create"
-  default = "Terraform"
+variable "domain" {
+  description = "Delivery server domain name"
+  default     = "localdomain"
+}
+variable "server_count" {
+  description = "Number of Delivery servers to provision. DO NOT CHANGE!"
+  default     = 1
+}
+variable "ent" {
+  description = "Name of the Chef Delivery enterprise to create"
+  default     = "Terraform"
 }
 variable "username" {
-  description = "Username of the first CHEF Delivery user"
-  default = "delivery"
+  description = "Username of the first Delivery user"
+  default     = "delivery"
 }
 variable "user_firstname" {
-  description = "Delivery user first name on CHEF Server"
-  default = "Delivery"
+  description = "Delivery user first name on Chef Server"
+  default     = "Delivery"
 }
 variable "user_lastname" {
-  description = "Delivery user last name on CHEF Server"
-  default = "User"
+  description = "Delivery user last name on Chef Server"
+  default     = "User"
 }
 variable "user_email" {
   description = "Delivery user's e-mail address"
   default = "delivery@domain.tld"
 }
-variable "ssh_cidrs" {
-  description = "List of CIDRs to allow SSH from"
-  default = "0.0.0.0/0"
+variable "allowed_cidrs" {
+  description = "List of CIDRs to allow SSH from (CSV list allowed)"
+  default     = "0.0.0.0/0"
 }
-variable "license_file" {
-  description = "Path to CHEF Delivery license file"
+variable "delivery_license" {
+  description = "Path to Delivery license file"
 }
-variable "chef_server_dns" {
-  description = "DNS address of the CHEF Server"
+variable "chef_fqdn" {
+  description = "Fully qualified DNS address of the Chef Server"
 }
-variable "chef_org_short" {
-  description = "CHEF Server organization short name (lowercase alphanumeric characters only)"
+variable "chef_org" {
+  description = "Chef Server organization short name (lowercase alphanumeric characters only)"
 }
-variable "chef_server_sg" {
-  description = "CHEF Server security group id"
+variable "chef_org_validator" {
+  descirption = "Path to validation pem for ${var.chef_org}"
+}
+variable "chef_sg" {
+  description = "Chef Server security group id"
+}
+variable "knife_rb" {
+  description = "Path to your knife.rb configuration"
+  default     = ".chef/knife.rb"
+}
+variable "r53_ttl" {
+  description = "Route53 A record TTL (Default: 180)"
+  default     = 180
+}
+variable "r53_zone_id" {
+  description = "Route53 Zone ID"
+  default     = 0
 }
 variable "secret_key_file" {
   description = "Encrypted data bag secret file"
+}
+variable "ssl_cert" {
+  description = "SSL Certificate in PEM format"
+}
+variable "ssl_key" {
+  description = "Key for SSL Certificate"
 }


### PR DESCRIPTION
- Re-wrote most of the code
- Some formatting to make reading easier
- Syntax updates for Terraform 0.6.14
- Add Route53 controls
- Add SSL certificate controls
- Replace hostname computation from basename and count to just hostname and domain
- Implement user and AMI mapping per [tf_chef_server](https://github.com/mengesb/tf_chef_server)
- Remove specific IPTables handles, disabling IPTables or UFW globally
- Better handle on delivery and keys databags
- Provisioning using Chef provisioner and attributes_json
- Using cookbooks at Chef server to govern system settings better than scripting EC2 variable hooks
- Using templates instead of all HEREDOC
- Doc and version updates
