### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ tf_chef_delivery CHANGELOG
 
 This file is used to list changes made in each version of the Terraform plan.
 
+v1.0.0 (2016-05-02)
+-------------------
+- [Brian Menges] - Add `accept_license` to handle Chef MLSA
+- [Brian Menges] - Add `delivery_version` to install specific Delivery version. Default: `latest`
+- [Brian Menges] - Add `root_volume_size` and `root_volume_type` variables to handle larger than default root volumes
+
 v0.3.9 (2016-04-26)
 -------------------
 - [Brian Menges] - Missing double quote in delivery credentials file write resource

--- a/files/attributes-json.tpl
+++ b/files/attributes-json.tpl
@@ -1,8 +1,10 @@
 {
   "delivery-cluster": {
     "delivery": {
+      "accept_license": ${license},
       "chef_server": "https://${chef_fqdn}/organizations/${chef_org}",
-      "fqdn": "${host}.${domain}"
+      "fqdn": "${host}.${domain}",
+      "version": "${version}"
     }
   },
   "fqdn": "${host}.${domain}",

--- a/main.tf
+++ b/main.tf
@@ -66,8 +66,10 @@ resource "template_file" "attributes-json" {
   vars {
     chef_fqdn = "${var.chef_fqdn}"
     chef_org  = "${var.chef_org}"
-    host      = "${var.hostname}"
     domain    = "${var.domain}"
+    host      = "${var.hostname}"
+    license   = "${var.accept_license}"
+    version   = "${var.delivery_version}"
   }
 }
 # Delivery builder databag template
@@ -77,7 +79,7 @@ resource "template_file" "delivery_builder_keys-json" {
     username  = "${var.username}"
   }
 }
-# Purge local cache directory
+# Local Prep
 resource "null_resource" "clean-slate" {
   provisioner "local-exec" {
     command = "rm -rf .delivery ; mkdir -p .delivery"
@@ -170,6 +172,8 @@ resource "aws_instance" "chef-delivery" {
   }
   root_block_device = {
     delete_on_termination = "${var.root_delete_termination}"
+    volume_size = "${var.root_volume_size}"
+    volume_type = "${var.root_volume_type}"
   }
   connection {
     user        = "${lookup(var.ami_usermap, var.ami_os)}"

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,10 @@ variable "ami_usermap" {
 #
 # specific configs
 #
+variable "accept_license" {
+  description = "Accept the Chef MLSA"
+  default     = false
+}
 variable "allowed_cidrs" {
   description = "List of CIDRs to allow SSH from (CSV list allowed)"
   default     = "0.0.0.0/0"
@@ -121,6 +125,10 @@ variable "client_version" {
 }
 variable "delivery_license" {
   description = "Path to Delivery license file"
+}
+variable "delivery_version" {
+  description = "Delivery Server version to install on instance"
+  default     = "latest"
 }
 variable "domain" {
   description = "Delivery server domain name"
@@ -149,6 +157,14 @@ variable "public_ip" {
 variable "root_delete_termination" {
   description = "Delete server root block device on termination"
   default     = true
+}
+variable "root_volume_size" {
+  description = "Size in GB of root device"
+  default     = 20
+}
+variable "root_volume_type" {
+  description = "Type of root volume"
+  default     = "standard"
 }
 variable "secret_key_file" {
   description = "Encrypted data bag secret file"


### PR DESCRIPTION
- [Brian Menges] - Add `accept_license` to handle Chef MLSA
- [Brian Menges] - Add `delivery_version` to install specific Delivery version. Default: `latest`
- [Brian Menges] - Add `root_volume_size` and `root_volume_type` variables to handle larger than default root volumes
